### PR TITLE
Add special handling code for 1-qx^2

### DIFF
--- a/simple_maker.sage
+++ b/simple_maker.sage
@@ -132,6 +132,9 @@ def create_line(Lpoly, polydata, simple = True):
         factor, power = factors[0]
         invs, places, newton_slopes = find_invs_places_and_slopes(polydata.p, polydata.r, factor)
         e = lcm([a.denominator() for a in invs])
+        # When q is not a square, the cases 1-qx^2 and 1+qx^2 must be handled separately.
+        if (not is_square(polydata.q)) and factor.degree() == 2 and factor[1] == 0:
+            e = 2
         if e != power:
             return ""
         angle_numbers = map(float, sorted(angles(Lpoly)))

--- a/simple_maker.sage
+++ b/simple_maker.sage
@@ -132,8 +132,8 @@ def create_line(Lpoly, polydata, simple = True):
         factor, power = factors[0]
         invs, places, newton_slopes = find_invs_places_and_slopes(polydata.p, polydata.r, factor)
         e = lcm([a.denominator() for a in invs])
-        # When q is not a square, the cases 1-qx^2 and 1+qx^2 must be handled separately.
-        if (not is_square(polydata.q)) and factor.degree() == 2 and factor[1] == 0:
+        # When q is not a square, the case 1-qx^2 must be handled separately.
+        if (not is_square(polydata.q)) and factor.degree() == 2 and factor[1] == 0 and factor[2]<0:
             e = 2
         if e != power:
             return ""

--- a/simple_maker.sage
+++ b/simple_maker.sage
@@ -133,7 +133,7 @@ def create_line(Lpoly, polydata, simple = True):
         invs, places, newton_slopes = find_invs_places_and_slopes(polydata.p, polydata.r, factor)
         e = lcm([a.denominator() for a in invs])
         # When q is not a square, the case 1-qx^2 must be handled separately.
-        if (not is_square(polydata.q)) and factor.degree() == 2 and factor[1] == 0 and factor[2]<0:
+        if (not is_square(polydata.q)) and factor.degree() == 2 and factor[1] == 0 and factor[0] < 0:
             e = 2
         if e != power:
             return ""


### PR DESCRIPTION
This is a modification to address

https://github.com/LMFDB/lmfdb/issues/2451

by correcting the handling of the Weyl polynomials 1-qx^2 and 1+qx^2 when q is not a perfect square.